### PR TITLE
ci(test): add a cleanup step before creating a new test release

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -10,12 +10,30 @@ jobs:
     if: ${{ github.triggering_actor == github.repository_owner }}
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Cleanup
+        run: |
+          ./entrypoint/utilities/extract-release.sh
+          source release_meta
+          if [[ -z ${release_id} || ${release_id} -gt 0 ]]
+          then
+            RELEASE_ID=${release_id} TAG_REF=${TAG_REF} ./entrypoint/utilities/cleanup-release.sh
+            echo "Stale release was deleted."
+          else
+            echo "Stale release does not exist."
+          fi
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TAG: "action-test"
+          TAG_REF: "refs/tags/action-test"
       - name: Create a release
         run: |
           RESPONSE=$(
             curl -s -L -X POST --oauth2-bearer ${{ secrets.ACTION_TEST_TOKEN }} \
             -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
-            --json '{"tag_name": "action-test", "name": "GitHub Action Test", "body": "## PLEASE IGNORE THIS RELEASE\nThis is a release to **test the GitHub Action**, which will be deleted once the test workflow completes successfully.", "prerelease": true}' \
+            --json '{"tag_name": "action-test", "target_commitish": "${{ github.sha }}", "name": "GitHub Action Test", "body": "## PLEASE IGNORE THIS RELEASE\nThis is a release to **test the GitHub Action**, which will be deleted once the test workflow completes successfully.", "prerelease": true}' \
             "https://api.github.com/repos/${{ github.repository }}/releases"
           )
           RELEASE_ID=$(echo -E ${RESPONSE} | jq -r ".id")

--- a/.github/workflows/scheduler-daily.yml
+++ b/.github/workflows/scheduler-daily.yml
@@ -1,0 +1,27 @@
+name: Daily Scheduler
+
+on:
+  schedule:
+    - cron: "30 18 * * *" # 0230 HKT every day
+
+jobs:
+  stale:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 30
+          days-before-close: 7
+          days-before-issue-close: -1
+          stale-issue-message: "This issue is stale because it has been open 30 days with no activity."
+          stale-pr-message: "This pull request is stale because it has been open 30 days with no activity. Please respond to this comment or this pull request will be closed in 7 days."
+          close-pr-message: "This pull request was closed because it has been stale 7 days with no activity."
+          stale-issue-label: "status: stale"
+          stale-pr-label: "status: stale"
+          exempt-issue-labels: "status: review required"
+          exempt-pr-labels: "status: review required"
+          ascending: true

--- a/.github/workflows/unit-test-release.yml
+++ b/.github/workflows/unit-test-release.yml
@@ -111,23 +111,10 @@ jobs:
     needs: [ test-default, test-action, test-author, test-override ]
     runs-on: ubuntu-latest
     steps:
-      - name: Delete the release
-        run: |
-          STATUS_CODE=$(
-            curl -s -L -X DELETE --oauth2-bearer ${{ github.token }} \
-            -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
-            -w "%{response_code}\n" -o /dev/null \
-            "https://api.github.com/repos/${{ github.repository }}/releases/${{ needs.test-default.outputs.release_id }}"
-          )
-          echo "Status: ${STATUS_CODE}"
-          if [ ${STATUS_CODE} -eq 204 ]; then exit 0; else exit 1; fi
-      - name: Delete the tag
-        run: |
-          STATUS_CODE=$(
-            curl -s -L -X DELETE --oauth2-bearer ${{ github.token }} \
-            -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
-            -w "%{response_code}\n" -o /dev/null \
-            "https://api.github.com/repos/${{ github.repository }}/git/refs/tags/action-test"
-          )
-          echo "Status: ${STATUS_CODE}"
-          if [ ${STATUS_CODE} -eq 204 ]; then exit 0; else exit 1; fi
+      - name: Delete the release and its associated tag
+        run: ./entrypoint/utilities/cleanup-release.sh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPO: ${{ github.repository }}
+          RELEASE_ID: ${{ needs.test-default.outputs.release_id }}
+          TAG_REF: ${{ github.ref }}

--- a/.github/workflows/unit-test-release.yml
+++ b/.github/workflows/unit-test-release.yml
@@ -111,6 +111,8 @@ jobs:
     needs: [ test-default, test-action, test-author, test-override ]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Delete the release and its associated tag
         run: ./entrypoint/utilities/cleanup-release.sh
         env:

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ See [action.yml](action.yml) for the full documentation.
 |----------------|--------------------------------------|
 | `release_id`   | The unique identifier of the release |
 | `release_name` | The name of the release              |
+| `release_url`  | The URL of the release               |
 
 ### Notes
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ outputs:
   release_name:
     description: "The name of the release"
     value: ${{ steps.release.outputs.release_name }}
+  release_url:
+    description: "The URL of the release"
+    value: ${{ steps.release.outputs.release_url }}
 
 runs:
   using: "composite"
@@ -42,12 +45,10 @@ runs:
         echo "profile_avatar=https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png" >> "${GITHUB_OUTPUT}"
     - if: ${{ inputs.post_as == 'author' }}
       id: profile-author
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const {sender} = context.payload;
-          core.setOutput('profile_name', sender.login);
-          core.setOutput('profile_avatar', sender.avatar_url);
+      shell: bash
+      run: |
+        echo "profile_name=${{ github.event.sender.login }}" >> "${GITHUB_OUTPUT}"
+        echo "profile_avatar=${{ github.event.sender.avatar_url }}" >> "${GITHUB_OUTPUT}"
     - id: profile
       shell: bash
       run: |
@@ -59,7 +60,8 @@ runs:
     - if: ${{ github.event_name == 'release' }}
       id: release
       shell: bash
-      run: $GITHUB_ACTION_PATH/entrypoint/release.sh
+      working-directory: ${{ github.action_path }}
+      run: ./entrypoint/release.sh
       env:
         DISCORD_WEBHOOK_URL: ${{ inputs.webhook_url }}
         DISCORD_WEBHOOK_NAME: ${{ steps.profile.outputs.webhook_name }}

--- a/entrypoint/release.sh
+++ b/entrypoint/release.sh
@@ -1,18 +1,9 @@
 #!/bin/bash
 
-RELEASE=$(
-  curl -s -L --oauth2-bearer ${GITHUB_TOKEN} \
-  -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
-  "https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${GITHUB_TAG}"
-)
-
-echo "> Extracting release information from GitHub..."
-RELEASE_ID=$(echo -E ${RELEASE} | jq -r ".id")
-RELEASE_NAME=$(echo -E ${RELEASE} | jq -r ".name")
-RELEASE_NOTE=$(echo -E ${RELEASE} | jq -r ".body")
+./entrypoint/utilities/extract-release.sh
 
 echo "> Posting release note to Discord..."
-MESSAGE="# :new: [${RELEASE_NAME}](https://github.com/${GITHUB_REPO}/releases/tag/${GITHUB_TAG}) is available now."$'\r\n\r\n'"${RELEASE_NOTE}"
+MESSAGE="$(cat release_message)"
 if [[ ${DISCORD_WEBHOOK_NAME} == "" && ${DISCORD_WEBHOOK_AVATAR} == "" ]]
 then
   echo "Using default name and avatar"
@@ -43,7 +34,6 @@ echo "Status: ${STATUS_CODE}"
 if [ ${STATUS_CODE} -ne 204 ]; then exit 1; fi
 
 echo "> Exporting release data to Action..."
-echo "release_id=${RELEASE_ID}" >> "${GITHUB_OUTPUT}"
-echo "release_name=${RELEASE_NAME}" >> "${GITHUB_OUTPUT}"
+echo "$(cat release_meta)" >> "${GITHUB_OUTPUT}"
 
 exit 0

--- a/entrypoint/utilities/cleanup-release.sh
+++ b/entrypoint/utilities/cleanup-release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "> Deleting the release..."
+echo "> Deleting release ${RELEASE_ID}..."
 STATUS_CODE=$(
   curl -s -L -X DELETE --oauth2-bearer ${GITHUB_TOKEN} \
   -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
@@ -10,7 +10,7 @@ STATUS_CODE=$(
 echo "Status: ${STATUS_CODE}"
 if [ ${STATUS_CODE} -ne 204 ]; then exit 1; fi
 
-echo "> Deleting the tag..."
+echo "> Deleting tag ${TAG_REF}..."
 STATUS_CODE=$(
   curl -s -L -X DELETE --oauth2-bearer ${GITHUB_TOKEN} \
   -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \

--- a/entrypoint/utilities/cleanup-release.sh
+++ b/entrypoint/utilities/cleanup-release.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo "> Deleting the release..."
+STATUS_CODE=$(
+  curl -s -L -X DELETE --oauth2-bearer ${GITHUB_TOKEN} \
+  -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+  -w "%{response_code}\n" -o /dev/null \
+  "https://api.github.com/repos/${GITHUB_REPO}/releases/${RELEASE_ID}"
+)
+echo "Status: ${STATUS_CODE}"
+if [ ${STATUS_CODE} -eq 204 ]; then exit 0; else exit 1; fi
+
+echo "> Deleting the tag..."
+STATUS_CODE=$(
+  curl -s -L -X DELETE --oauth2-bearer ${GITHUB_TOKEN} \
+  -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+  -w "%{response_code}\n" -o /dev/null \
+  "https://api.github.com/repos/${GITHUB_REPO}/git/${TAG_REF}"
+)
+echo "Status: ${STATUS_CODE}"
+if [ ${STATUS_CODE} -eq 204 ]; then exit 0; else exit 1; fi

--- a/entrypoint/utilities/cleanup-release.sh
+++ b/entrypoint/utilities/cleanup-release.sh
@@ -8,7 +8,7 @@ STATUS_CODE=$(
   "https://api.github.com/repos/${GITHUB_REPO}/releases/${RELEASE_ID}"
 )
 echo "Status: ${STATUS_CODE}"
-if [ ${STATUS_CODE} -eq 204 ]; then exit 0; else exit 1; fi
+if [ ${STATUS_CODE} -ne 204 ]; then exit 1; fi
 
 echo "> Deleting the tag..."
 STATUS_CODE=$(
@@ -18,4 +18,6 @@ STATUS_CODE=$(
   "https://api.github.com/repos/${GITHUB_REPO}/git/${TAG_REF}"
 )
 echo "Status: ${STATUS_CODE}"
-if [ ${STATUS_CODE} -eq 204 ]; then exit 0; else exit 1; fi
+if [ ${STATUS_CODE} -ne 204 ]; then exit 1; fi
+
+exit 0

--- a/entrypoint/utilities/extract-release.sh
+++ b/entrypoint/utilities/extract-release.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+RELEASE=$(
+  curl -s -L --oauth2-bearer ${GITHUB_TOKEN} \
+  -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+  "https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${GITHUB_TAG}"
+)
+
+echo "> Extracting release information from GitHub..."
+
+# release meta
+RELEASE_ID=$(echo -E ${RELEASE} | jq -r ".id")
+RELEASE_NAME=$(echo -E ${RELEASE} | jq -r ".name")
+RELEASE_URL=$(echo -E ${RELEASE} | jq -r ".html_url")
+echo "release_id=${RELEASE_ID}" >> release_meta
+echo "release_name=${RELEASE_NAME}" >> release_meta
+echo "release_url=${RELEASE_URL}" >> release_meta
+
+# release note
+RELEASE_NOTE=$(echo -E ${RELEASE} | jq -r ".body")
+echo "# :new: [${RELEASE_NAME}](${RELEASE_URL}) is available now."$'\r\n\r\n'"${RELEASE_NOTE}" >> release_message

--- a/entrypoint/utilities/extract-release.sh
+++ b/entrypoint/utilities/extract-release.sh
@@ -12,10 +12,12 @@ echo "> Extracting release information from GitHub..."
 RELEASE_ID=$(echo -E ${RELEASE} | jq -r ".id")
 RELEASE_NAME=$(echo -E ${RELEASE} | jq -r ".name")
 RELEASE_URL=$(echo -E ${RELEASE} | jq -r ".html_url")
-echo "release_id=${RELEASE_ID}" >> release_meta
+echo "release_id=${RELEASE_ID}" > release_meta
 echo "release_name=${RELEASE_NAME}" >> release_meta
 echo "release_url=${RELEASE_URL}" >> release_meta
 
 # release note
 RELEASE_NOTE=$(echo -E ${RELEASE} | jq -r ".body")
-echo "# :new: [${RELEASE_NAME}](${RELEASE_URL}) is available now."$'\r\n\r\n'"${RELEASE_NOTE}" >> release_message
+echo "# :new: [${RELEASE_NAME}](${RELEASE_URL}) is available now."$'\r\n\r\n'"${RELEASE_NOTE}" > release_message
+
+exit 0


### PR DESCRIPTION
## Summary

### What does the pull request change?
- Add a cleanup step at the start of the integration test workflow to remove any existing test release and tag before creating a new one.
- Refactor "extract release" and "cleanup release" logic into reusable utility shell scripts for easier use across workflows.

### How can the pull request improve the action?
- Ensure the integration test workflow can always create a new test release, regardless of previous unit test status, reducing manual cleanup and workflow failures.
- Improve maintainability and consistency by enabling code reuse for release management tasks across different workflows.

## Related Issue

Closes #1 
