### PR TITLE
ci(workflow): run test suite on pull requests and enforce label-based blocking rules

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -2,17 +2,37 @@ name: Integration Test
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - "main"
+      - "preview"
+      - "releases/**"
+    paths:
+      - "action.yml"
+      - "entrypoint/**/*.sh"
 
 jobs:
-  trigger:
+  trigger-release:
     permissions:
       contents: write
-    if: ${{ github.triggering_actor == github.repository_owner }}
+    if: ${{ github.event_name == 'pull_request' || github.triggering_actor == github.repository_owner }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
+        id: checkout
         uses: actions/checkout@v4
+      - name: Generate the tag name
+        id: tag
+        run: |
+          if [[ ${{ github.event_name }} == pull_request ]]
+          then
+            TAG_NAME="action-test/${{ github.ref_name }}"
+          else
+            TAG_NAME="action-test/manual/${{ github.ref_name }}"
+          fi
+          echo "tag_name=${TAG_NAME}" >> "${GITHUB_OUTPUT}"
       - name: Cleanup
+        id: cleanup
         run: |
           ./entrypoint/utilities/extract-release.sh
           source release_meta
@@ -26,14 +46,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPO: ${{ github.repository }}
-          GITHUB_TAG: "action-test"
-          TAG_REF: "refs/tags/action-test"
+          GITHUB_TAG: ${{ steps.tag.outputs.tag_name }}
+          TAG_REF: "refs/tags/${{ steps.tag.outputs.tag_name }}"
       - name: Create a release
+        id: release
         run: |
           RESPONSE=$(
             curl -s -L -X POST --oauth2-bearer ${{ secrets.ACTION_TEST_TOKEN }} \
             -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
-            --json '{"tag_name": "action-test", "target_commitish": "${{ github.sha }}", "name": "GitHub Action Test", "body": "## PLEASE IGNORE THIS RELEASE\nThis is a release to **test the GitHub Action**, which will be deleted once the test workflow completes successfully.", "prerelease": true}' \
+            --json '{"tag_name": "${{ steps.tag.outputs.tag_name }}", "target_commitish": "${{ github.sha }}", "name": "GitHub Action Test (${{ github.ref_name }})", "body": "## PLEASE IGNORE THIS RELEASE\nThis is a release to **test the GitHub Action**, which will be deleted once the test workflow completes successfully.", "prerelease": true}' \
             "https://api.github.com/repos/${{ github.repository }}/releases"
           )
           RELEASE_ID=$(echo -E ${RESPONSE} | jq -r ".id")

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -2,14 +2,7 @@ name: Integration Test
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - "main"
-      - "preview"
-      - "releases/**"
-    paths:
-      - "action.yml"
-      - "entrypoint/**/*.sh"
+  workflow_call:
 
 jobs:
   trigger-release:
@@ -26,7 +19,7 @@ jobs:
         run: |
           if [[ ${{ github.event_name }} == pull_request ]]
           then
-            TAG_NAME="action-test/${{ github.ref_name }}"
+            TAG_NAME="action-test/pr/${{ github.event.pull_request.number }}"
           else
             TAG_NAME="action-test/manual/${{ github.ref_name }}"
           fi

--- a/.github/workflows/label-pull-request.yml
+++ b/.github/workflows/label-pull-request.yml
@@ -1,0 +1,48 @@
+name: Label
+
+on:
+  pull_request:
+    types: [ labeled, unlabeled ]
+
+jobs:
+  # to resolve workflow syntax limitation (jobs.<job_id>.if)
+  preprocess:
+    runs-on: ubuntu-latest
+    outputs:
+      labels: ${{ join(github.event.pull_request.labels.*.name, ', ') }}
+    steps:
+      - name: Set exit code
+        run: exit 0
+
+  block-by-no-merge:
+    needs: [ preprocess ]
+    if: ${{ contains(needs.preprocess.outputs.labels, 'no merge') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: |
+          Fail the status check if the pull request is labeled as 'no merge'
+        run: |
+          echo "This PR is labeled as 'no merge'. All tests must pass before merging."
+          exit 1
+
+  block-by-feedback-required:
+    needs: [ preprocess ]
+    if: ${{ contains(needs.preprocess.outputs.labels, 'feedback required') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: |
+          Fail the status check if the pull request is labeled as 'status: feedback required'
+        run: |
+          echo "This PR is labeled as 'status: feedback required'. Additional information is needed before proceeding."
+          exit 1
+
+  block-by-review-required:
+    needs: [ preprocess ]
+    if: ${{ contains(needs.preprocess.outputs.labels, 'review required') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: |
+          Fail the status check if the pull request is labeled as 'status: review required'
+        run: |
+          echo "This PR is labeled as 'status: review required'. Approval from reviewers is needed prior to merging."
+          exit 1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,37 @@
+name: Pull Request
+
+on:
+  pull_request:
+    branches:
+      - "main"
+      - "preview"
+      - "releases/**"
+    paths:
+      - "action.yml"
+      - "entrypoint/**/*.sh"
+      - ".github/workflows/**/*.yml"
+
+jobs:
+  label-no-merge:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add 'no merge' label to the updated pull request
+        run: |
+          STATUS_CODE=$(
+            curl -s -L -X POST --oauth2-bearer ${{ secrets.ACTION_TEST_TOKEN }} \
+            -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+            -w "%{response_code}\n" -o /dev/null \
+            --json '{"labels": ["no merge"]}' \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels"
+          )
+          echo "Status: ${STATUS_CODE}"
+          if [ ${STATUS_CODE} -ne 200 ]; then exit 1; fi
+
+  run-test:
+    permissions:
+      contents: write
+    needs: [ label-no-merge ]
+    uses: ./.github/workflows/integration-test.yml
+    secrets: inherit

--- a/.github/workflows/unit-test-release.yml
+++ b/.github/workflows/unit-test-release.yml
@@ -8,7 +8,7 @@ jobs:
   test-default:
     permissions:
       contents: read
-    if: ${{ github.ref == 'refs/tags/action-test' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/action-test/') }}
     strategy:
       matrix:
         runs-on: [ ubuntu-latest, macos-latest, windows-latest ]
@@ -28,7 +28,7 @@ jobs:
   test-action:
     permissions:
       contents: read
-    if: ${{ github.ref == 'refs/tags/action-test' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/action-test/') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -44,7 +44,7 @@ jobs:
   test-author:
     permissions:
       contents: read
-    if: ${{ github.ref == 'refs/tags/action-test' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/action-test/') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -60,7 +60,7 @@ jobs:
   test-override:
     permissions:
       contents: read
-    if: ${{ github.ref == 'refs/tags/action-test' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/action-test/') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/unit-test-release.yml
+++ b/.github/workflows/unit-test-release.yml
@@ -8,7 +8,7 @@ jobs:
   test-default:
     permissions:
       contents: read
-    if: ${{ startsWith(github.ref, 'refs/tags/action-test/') }}
+    if: ${{ startsWith(github.event.release.tag_name, 'action-test/') }}
     strategy:
       matrix:
         runs-on: [ ubuntu-latest, macos-latest, windows-latest ]
@@ -28,7 +28,7 @@ jobs:
   test-action:
     permissions:
       contents: read
-    if: ${{ startsWith(github.ref, 'refs/tags/action-test/') }}
+    if: ${{ startsWith(github.event.release.tag_name, 'action-test/') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -44,7 +44,7 @@ jobs:
   test-author:
     permissions:
       contents: read
-    if: ${{ startsWith(github.ref, 'refs/tags/action-test/') }}
+    if: ${{ startsWith(github.event.release.tag_name, 'action-test/') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -60,7 +60,7 @@ jobs:
   test-override:
     permissions:
       contents: read
-    if: ${{ startsWith(github.ref, 'refs/tags/action-test/') }}
+    if: ${{ startsWith(github.event.release.tag_name, 'action-test/') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -120,3 +120,17 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
           RELEASE_ID: ${{ needs.test-default.outputs.release_id }}
           TAG_REF: ${{ github.ref }}
+
+  unlabel-no-merge:
+    permissions:
+      pull-requests: write
+    needs: [ cleanup ]
+    if: ${{ startsWith(github.event.release.tag_name, 'action-test/pr/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove 'no merge' label from the passed pull request
+        run: |
+          PR_NUMBER=$(echo "${{ github.event.release.tag_name }}" | sed -e "s/action-test\/pr\///g")
+          curl -s -L -X DELETE --oauth2-bearer ${{ secrets.ACTION_TEST_TOKEN }} \
+          -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+          "https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/labels/no%20merge"


### PR DESCRIPTION
## Summary

### What does the pull request change?
- Introduce a CI workflow to automatically run the project’s test suite on every pull request.
- Automatically add the `no merge` label to pull requests before tests start, and remove it only after all tests succeed.
- Block merging of any pull request labeled with `no merge`, `status: feedback required`, or `status: review required`.

### How can the pull request improve the action?
- Ensure code is tested before merging, catching issues sooner.
- Prevent unstable or unreviewed code from being merged, enforcing higher code quality.
- Streamline the review process and reduce manual intervention by using labels to block or allow merges based on test and review status.

## Related Issue

Closes #3 
